### PR TITLE
Workaround for DBI warnings about active statement handles when using dbi_prepare_method => prepare_cached

### DIFF
--- a/lib/DBIx/DataModel/Source/Table.pm
+++ b/lib/DBIx/DataModel/Source/Table.pm
@@ -61,6 +61,7 @@ sub _singleInsert {
   my @returned_vals;
   if ($options{-returning} && (ref $options{-returning} || '') ne 'HASH') {
     @returned_vals = $sth->fetchrow_array;
+    $sth->finish;
   }
 
   # if needed, retrieve the primary key

--- a/lib/DBIx/DataModel/Statement.pm
+++ b/lib/DBIx/DataModel/Statement.pm
@@ -464,7 +464,11 @@ sub select {
     /^(rows|arrayref)$/i  and return $self->all;
 
     # CASE firstrow : just the first row
-    /^firstrow$/i   and return $self->next;
+    /^firstrow$/i   and do {
+      my $row = $self->next;
+      $self->{sth}->finish;
+      return $row;
+    };
 
     # CASE hashref : all data rows, put into a hashref
     /^hashref$/i   and do {


### PR DESCRIPTION
We're using DBIx::DataModel with dbi_prepare_method => 'prepare_cached'. Unfortnately, DBI complains about "statement handles still Active" on `fetch()` and `insert( -returning => ... )` operations. This is caused by the fact that `$sth` remains active unless `fetchrow_*` is called in a loop until it returns false, or `$sth->finish` is called explicitly. Both `fetch()` and `insert( -returning => ... )` use a single `fetchrow_array` without a loop or `finish()` and their statement remains active, so when prepare_cached is used again for the same query, DBI issues a warning.

I've added a simple workaround, which calls `$sth->finish()` in statement returning the first row only and in insert.
