### PR TITLE
fix: let SQL::Abstract quote identifiers in ON conditions

### DIFF
--- a/lib/DBIx/DataModel/Meta/Schema.pm
+++ b/lib/DBIx/DataModel/Meta/Schema.pm
@@ -390,7 +390,8 @@ sub _parse_join_path {
       my $right_table = $alias || $path->{to}->db_from;
       my %condition;
       while (my ($left_col, $right_col) = each %{$path->{on}}) {
-        $condition{"$left_table.$left_col"} = \"= $right_table.$right_col";
+        # FIXME: honor SQL::Abstract's "name_sep" setting
+        $condition{"$left_table.$left_col"} = { -ident => "$right_table.$right_col" };
       }
       my $db_table = $path->{to}->db_from;
       $db_table .= "|$alias" if $alias;


### PR DESCRIPTION
similar to SQL::Abstract::More it's better to use { -ident => $ident } syntax to let SQL::Abstract quote properly  right operand in ON condition.

At the same time I wasn't to get SQLA instance from meta schema to honor "name_sep" setting. Dot it still hardcoded.