### PR TITLE
fix $statement->row_count()

### DIFF
--- a/t/v2_union.t
+++ b/t/v2_union.t
@@ -60,7 +60,7 @@ __EOSQL__
       SELECT emp_id, firstname, lastname FROM T_Employee WHERE ( d_birth = ? )
       UNION 
       SELECT emp_id, firstname, lastname FROM T_Employee WHERE ( d_spouse = ? )
-    )
+    ) AS count_wrapper
 __EOSQL__
 
 }


### PR DESCRIPTION
* always wrap DISTINCT in subquery because it changes number of rows in result set
 Example:  SELECT DISTINCT id FROM t;
resulted in (total number of rows rather than unique)
 SELECT COUNT(*) FROM t;
* wrap unknown queries
- PostgreSQL allows to call stored procedure (that returns result set) instead of real table, so FROM clause is not always used.
Example: SELECT proc(1,2,3);
- PostgreSQL  Common Table Expression (called CTE) queries starts with WITH clause.
- PostgreSQL requires an alias for subqueries (it's supported by SQL standard, but optional in TSQL, Oracle at least)